### PR TITLE
Revert "[build] Fix missing deps in dune rule for All.v file"

### DIFF
--- a/theories/dune
+++ b/theories/dune
@@ -1,10 +1,7 @@
 (include_subdirs qualified)
-
-; We omit All.v as not to block on rocq-core build
 (coq.theory
  (name Stdlib)
- (package rocq-stdlib)
- (modules :standard \ All))
+ (package rocq-stdlib))
 
 (env
  (dev
@@ -13,5 +10,5 @@
 
 (rule
  (targets All.v)
- (deps (package rocq-core) All.sh (source_tree .))
+ (deps All.sh (source_tree .))
  (action (with-stdout-to %{targets} (run env bash ./All.sh))))


### PR DESCRIPTION
Reverting https://github.com/rocq-prover/stdlib/pull/188 for now, until a better solution is found.