### PR TITLE
Adapt to Rocq PR # 20985 (backward compatible hint)

### DIFF
--- a/theories/micromega/Tauto.v
+++ b/theories/micromega/Tauto.v
@@ -289,7 +289,8 @@ Section S.
 
 End S.
 
-
+#[global]
+Hint Extern 2 (subrelation (eiff _) _) => progress cbn : typeclass_instances.
 
 (** Typical boolean formulae *)
 Definition eKind (k: kind) := if k then Prop else bool.


### PR DESCRIPTION
The Rocq PR rocq-prover/rocq#20985 adds support for generalized rewriting in let-bindings. It changes the basic `subrelation` instances on `eq`, `iff` and `impl` to avoid proof search blowup. The fix here should actually improve performance if it has any visible effect.