### PR TITLE
Add a Version file allowing to identify the stdlib version from Rocq

### DIFF
--- a/dev/doc/howto_release.md
+++ b/dev/doc/howto_release.md
@@ -1,6 +1,7 @@
 * generate changelog with dev/tools/generate-release-changelog.sh
   and update doc/sphinx/changes.rst accordingly
 * update doc/sphinx/conf.py (particularly is_a_released_version)
+* update theories/Version.v
 * check the result of "make refman-html"
   (in _build/default/doc/refman-html)
 * if need be, update supported versions of Rocq in .nix/config.nix

--- a/theories/All.sh
+++ b/theories/All.sh
@@ -10,5 +10,7 @@ if [ "$1" = "-unsorted" ]; then
 else
   rocqdep="xargs rocq dep -Q . Stdlib -sort"
 fi
-find . -regex '.*/[^.][^/]*[.]v' ! -path ./All.v | sort | $rocqdep | \
+find . -regex '.*/[^.][^/]*[.]v' ! -path ./All.v ! -path ./Version.v | sort | $rocqdep | \
   sed -e 's#\./#From Stdlib Require Export #g' -e 's#\.v\s*#.\n#g' -e 's#/#.#g'
+
+printf 'From Stdlib Require Export Version.\n'

--- a/theories/Version.v
+++ b/theories/Version.v
@@ -1,0 +1,2 @@
+From Corelib Require Import PrimString.
+Definition version : string := "9.2".


### PR DESCRIPTION
Part of a fix for #256, allowing to identify the released version of stdlib however it has been installed.

<!-- Remove anything that doesn't apply in the following checklist. -->

<!-- If this is a feature pull request / breaks compatibility: -->
- [ ] Added **changelog**. (is this necessary?)
- [x] Added / updated **documentation**. (notes for the release process)