### PR TITLE
Update links when importing vectors and Fin

### DIFF
--- a/theories/Vectors/Fin.v
+++ b/theories/Vectors/Fin.v
@@ -15,14 +15,14 @@ From Stdlib Require Arith_base.
 bounded integers. Another popular approach is to bundle integers with
 a proof of boundedness, thus inheriting integer arithmetic rather than
 redefining it on the bounded type. See
-https://github.com/coq/stdlib/blob/master/theories/Vectors/Vector.v
+https://github.com/rocq-prover/stdlib/blob/master/theories/Vectors/Vector.v
 for a similar discussion on bounded lists.
 
 An alternative implementation can be found for instance in
-https://github.com/math-comp/math-comp/blob/master/mathcomp/ssreflect/fintype.v
+https://github.com/math-comp/math-comp/blob/master/boot/fintype.v
 One can read more about this type in section 7.4 of this book:
 https://zenodo.org/record/4282710#.X_q4aGso-yU . *)
-Attributes warn(cats="stdlib vector", note="Alternatives to Fin.t are available, see <https://github.com/coq/stdlib/blob/master/theories/Vectors/Fin.v>.").
+Attributes warn(cats="stdlib vector", note="Alternatives to Fin.t are available, see <https://github.com/rocq-prover/stdlib/blob/master/theories/Vectors/Fin.v>.").
 
 (** [fin n] is a way to represent \[1 .. n\]
 

--- a/theories/Vectors/Vector.v
+++ b/theories/Vectors/Vector.v
@@ -22,7 +22,7 @@ equal.) This decouples the two aspects above, making it easy to write
 code in Gallina and develop proofs with tactics.
 
 Such an implementation can be found for instance in
-https://github.com/math-comp/math-comp/blob/master/mathcomp/ssreflect/tuple.v
+https://github.com/math-comp/math-comp/blob/master/boot/tuple.v
 One can read more about this tuple type in section 7.1 of this book:
 https://doi.org/10.5281/zenodo.4282710 .
 In particular, this implementation comes with coercion and canonical
@@ -69,7 +69,7 @@ Check rev t : tuple_of n T.
 ]]
 
 Thus lemmas about lists are enough in most cases. *)
-Attributes warn(cats="stdlib vector", note="Using Vector.t is known to be technically difficult, see <https://github.com/coq/stdlib/blob/master/theories/Vectors/Vector.v>.").
+Attributes warn(cats="stdlib vector", note="Using Vector.t is known to be technically difficult, see <https://github.com/rocq-prover/stdlib/blob/master/theories/Vectors/Vector.v>.").
 
 (** Vectors.
 

--- a/theories/Vectors/VectorDef.v
+++ b/theories/Vectors/VectorDef.v
@@ -9,8 +9,8 @@
 (************************************************************************)
 
 (** N.B.: Using this encoding of vectors is discouraged.
-See <https://github.com/coq/stdlib/blob/master/theories/Vectors/Vector.v>. *)
-Attributes warn(cats="stdlib vector", note="Using Vector.t is known to be technically difficult, see <https://github.com/coq/stdlib/blob/master/theories/Vectors/Vector.v>.").
+See <https://github.com/rocq-prover/stdlib/blob/master/theories/Vectors/Vector.v>. *)
+Attributes warn(cats="stdlib vector", note="Using Vector.t is known to be technically difficult, see <https://github.com/rocq-prover/stdlib/blob/master/theories/Vectors/Vector.v>.").
 
 (** Definitions of Vectors and functions to use them
 

--- a/theories/Vectors/VectorEq.v
+++ b/theories/Vectors/VectorEq.v
@@ -10,7 +10,7 @@
 
 (** N.B.: Using this encoding of vectors is discouraged.
 See <https://github.com/coq/stdlib/blob/master/theories/Vectors/Vector.v>. *)
-Attributes warn(cats="stdlib vector", note="Using Vector.t is known to be technically difficult, see <https://github.com/coq/stdlib/blob/master/theories/Vectors/Vector.v>.").
+Attributes warn(cats="stdlib vector", note="Using Vector.t is known to be technically difficult, see <https://github.com/rocq-prover/stdlib/blob/master/theories/Vectors/Vector.v>.").
 
 (** Equalities and Vector relations
 

--- a/theories/Vectors/VectorSpec.v
+++ b/theories/Vectors/VectorSpec.v
@@ -10,7 +10,7 @@
 
 (** N.B.: Using this encoding of vectors is discouraged.
 See <https://github.com/coq/stdlib/blob/master/theories/Vectors/Vector.v>. *)
-Attributes warn(cats="stdlib vector", note="Using Vector.t is known to be technically difficult, see <https://github.com/coq/stdlib/blob/master/theories/Vectors/Vector.v>.").
+Attributes warn(cats="stdlib vector", note="Using Vector.t is known to be technically difficult, see <https://github.com/rocq-prover/stdlib/blob/master/theories/Vectors/Vector.v>.").
 
 (** Proofs of specification for functions defined over Vector
 


### PR DESCRIPTION
Updated links from the former coq/coq repo to rocq-prover/stdlib, as well as fixing broken matchcomp links in comments in the corresponding linked files.